### PR TITLE
from stream for all files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.19
+        go-version: 1.23.0
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Refactored the update process to use a stream-based file replacement method for all files, not just binaries. This improves consistency and reliability, especially on Windows.

- **Refactors**
  - Replaced the old binary-specific update function with a generic file replacement function.
  - Updated all relevant code paths to use the new function.

<!-- End of auto-generated description by cubic. -->

